### PR TITLE
Removes invasive rpc logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# The GoVector log files from the tests
+*.txt
+
 # Dependency directories (remove the comment below to include it)
 # vendor/


### PR DESCRIPTION
When running the trace server, one would typically get the following logs:
```
2021/01/21 22:11:19 rpc.Register: method "Accept" has 1 input parameters; needs exactly three
2021/01/21 22:11:19 rpc.Register: method "Close" has 1 input parameters; needs exactly three
2021/01/21 22:11:19 rpc.Register: method "Open" has 1 input parameters; needs exactly three
```

and

```
2021/01/21 22:11:26 rpc.Serve: accept:accept tcp [::]:6666: use of closed network connection
```

This PR fixes both of those to disable the logs.

For the `register` logs:
- Created a struct that has exactly one method (the `RecordAction`) and we register that, as opposed to the whole `tracingServer`

For the `accept` logs:
- Implement exactly what the `rpc.Server.Accept` does, except omit the invasive logs

Obviously, since no one asked for this fix, feel free to close it if it's not needed, I just thought I might as well fix this :)